### PR TITLE
Integrating Clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,44 @@
+---
+Checks:          '-*,bugprone-*,cppcoreguidelines-*,modernize-*,concurrency-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+CheckOptions:
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           '0'
+  - key:             llvm-else-after-return.WarnOnUnfixable
+    value:           '0'
+  - key:             llvm-qualified-auto.AddConstToQualified
+    value:           '0'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...

--- a/.github/workflows/clang_tidy_manual.yml
+++ b/.github/workflows/clang_tidy_manual.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run clang-tidy and generate SARIF files
         run: |
           mkdir sarif_results
-          SOURCE_FILES=$(find $GITHUB_WORKSPACE -path "$GITHUB_WORKSPACE/third_party" -prune -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.h' -o -name '*.hh' -o -name '*.hxx' \))
+          SOURCE_FILES=$(find $GITHUB_WORKSPACE -path "$GITHUB_WORKSPACE/third_party" -prune -o -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.h' -o -name '*.hh' -o -name '*.hxx' \) -print)
           for FILE in $SOURCE_FILES; do
             BASENAME=$(basename -- "$FILE")
             SARIF_FILE="sarif_results/${BASENAME%.*}.sarif"

--- a/.github/workflows/clang_tidy_manual.yml
+++ b/.github/workflows/clang_tidy_manual.yml
@@ -1,0 +1,51 @@
+on:
+  workflow_dispatch:
+
+name: ClangTidyCompleteCodebaseReview
+
+jobs:
+  upload-sarif:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+        
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - run: cargo install clang-tidy-sarif sarif-fmt
+
+      - name: Generate Compilation Database
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+
+      - name: Run clang-tidy and generate SARIF files
+        run: |
+          mkdir sarif_results
+          SOURCE_FILES=$(find $GITHUB_WORKSPACE -path "$GITHUB_WORKSPACE/third_party" -prune -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.h' -o -name '*.hh' -o -name '*.hxx' \))
+          for FILE in $SOURCE_FILES; do
+            BASENAME=$(basename -- "$FILE")
+            SARIF_FILE="sarif_results/${BASENAME%.*}.sarif"
+            USARIF_FILE="sarif_results/updated_${SARIF_BASENAME}.sarif"
+            clang-tidy -p=build "$FILE" -- | clang-tidy-sarif | tee "$SARIF_FILE"
+            # Make SARIF paths relative
+            jq --arg base "$GITHUB_WORKSPACE/" '.runs[].results[].locations[].physicalLocation.artifactLocation.uri |= sub($base; "")' "$SARIF_FILE" > "$USARIF_FILE"
+            mv "$USARIF_FILE" "$SARIF_FILE"
+            jq -s '{ version: .[0].version, runs: [ { tool: .[0].runs[0].tool, results: (map(.runs[0].results) | add) } ] }' sarif_results/*.sarif > merged_sarif_results.sarif
+          done
+
+      - name: Upload SARIF files
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: merged_sarif_results.sarif

--- a/.github/workflows/clang_tidy_review.yml
+++ b/.github/workflows/clang_tidy_review.yml
@@ -1,0 +1,37 @@
+name: ClangTidyReviewDiff
+
+# You can be more specific, but it currently only works on pull requests
+on: [pull_request]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    # Optionally generate compile_commands.json
+
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+
+    - uses: ZedThree/clang-tidy-review@v0.14.0
+      id: review
+      with:
+        build_dir: build
+        config_file: ".clang-tidy"
+        max_comments: '100'
+        exclude: "third_party/*"
+        cmake_command: |
+          cmake --version && \
+          git config --global --add safe.directory "$GITHUB_WORKSPACE" && \
+          cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=on
+          
+    # Uploads an artefact containing clang_fixes.json
+    - uses: ZedThree/clang-tidy-review/upload@v0.14.0
+      id: upload-review
+    # If there are any comments, fail the check
+    - if: steps.review.outputs.total_comments > 0
+      run: exit 1


### PR DESCRIPTION
Two new GitHub Actions have been included in this commit. 

1. ClangTidyDiffReview:
This is aimed to lint the new changes being made to the repository. The clang-tidy warnings and errors are given as a comment to the PR. Making new commit to the same PR will give new comments. 

2. ClangTidyCompleteReview: 
This an on-demand workflow which can be run, to populate the existing warnings and errors into the code scanning alerts in GHAS. This can be taken up and fixed over the time. Running it again will close the fixed issues and only the remaining will be posted. 

The .clang-tidy file can be used to configure the clang-tidy checks for both the actions.  