### PR TITLE
Added GitHub action to lint new changes with clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,44 @@
+---
+Checks:          '-*,bugprone-*,cppcoreguidelines-*,modernize-*,concurrency-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+CheckOptions:
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           '0'
+  - key:             llvm-else-after-return.WarnOnUnfixable
+    value:           '0'
+  - key:             llvm-qualified-auto.AddConstToQualified
+    value:           '0'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,30 +5,10 @@ HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     file
 CheckOptions:
-  - key:             cert-dcl16-c.NewSuffixes
-    value:           'L;LL;LU;LLU'
-  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
-    value:           '0'
-  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
-    value:           '0'
   - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
-    value:           '1'
+    value:           'false'
   - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value:           '1'
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
-  - key:             google-readability-function-size.StatementThreshold
-    value:           '800'
-  - key:             google-readability-namespace-comments.ShortNamespaceLines
-    value:           '10'
-  - key:             google-readability-namespace-comments.SpacesBeforeComments
-    value:           '2'
-  - key:             llvm-else-after-return.WarnOnConditionVariables
-    value:           '0'
-  - key:             llvm-else-after-return.WarnOnUnfixable
-    value:           '0'
-  - key:             llvm-qualified-auto.AddConstToQualified
-    value:           '0'
   - key:             modernize-loop-convert.MaxCopySize
     value:           '16'
   - key:             modernize-loop-convert.MinConfidence

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks:          '-*,bugprone-*,cppcoreguidelines-*,modernize-*,concurrency-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     file
 CheckOptions:
   - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors

--- a/.github/workflows/clang_tidy_diff_review.yml
+++ b/.github/workflows/clang_tidy_diff_review.yml
@@ -1,0 +1,37 @@
+name: ClangTidyDiffReview
+
+# You can be more specific, but it currently only works on pull requests
+on: [pull_request]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    # Optionally generate compile_commands.json
+
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+
+    - uses: ZedThree/clang-tidy-review@v0.14.0
+      id: review
+      with:
+        build_dir: build
+        config_file: ".clang-tidy"
+        max_comments: '100'
+        exclude: "third_party/*"
+        cmake_command: |
+          cmake --version && \
+          git config --global --add safe.directory "$GITHUB_WORKSPACE" && \
+          cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=on
+          
+    # Uploads an artefact containing clang_fixes.json
+    - uses: ZedThree/clang-tidy-review/upload@v0.14.0
+      id: upload-review
+    # If there are any comments, fail the check
+    - if: steps.review.outputs.total_comments > 0
+      run: exit 1

--- a/.github/workflows/clang_tidy_diff_review.yml
+++ b/.github/workflows/clang_tidy_diff_review.yml
@@ -20,6 +20,7 @@ jobs:
     - uses: ZedThree/clang-tidy-review@v0.14.0
       id: review
       with:
+        split_workflow: true
         build_dir: build
         config_file: ".clang-tidy"
         max_comments: '100'

--- a/.github/workflows/clang_tidy_post_diff_review_comments.yml
+++ b/.github/workflows/clang_tidy_post_diff_review_comments.yml
@@ -1,0 +1,21 @@
+name: PostClangTidyReviewComments
+
+on:
+  workflow_run:
+    # The name field of the lint action
+    workflows: ["clang-tidy-review-diff"]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: ZedThree/clang-tidy-review/post@v0.14.0
+        # lgtm_comment_body, max_comments, and annotations need to be set on the posting workflow in a split setup
+        with:
+          # adjust options as necessary
+          lgtm_comment_body: 'No warnings, LGTM!'
+          annotations: false
+          max_comments: 100

--- a/.github/workflows/clang_tidy_post_diff_review_comments.yml
+++ b/.github/workflows/clang_tidy_post_diff_review_comments.yml
@@ -3,7 +3,7 @@ name: PostClangTidyReviewComments
 on:
   workflow_run:
     # The name field of the lint action
-    workflows: ["clang-tidy-review-diff"]
+    workflows: ["ClangTidyDiffReview"]
     types:
       - completed
 


### PR DESCRIPTION
ClangTidyDiffReview action uses the clang-tidy-review action available on the marketplace. 
This is aimed to lint the new changes being made to the repository. The clang-tidy warnings and errors are given as a comment to the PR. Making new commit to the same PR will give new comments.