### PR TITLE
Added GitHub action to lint the complete codebase using clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,44 @@
+---
+Checks:          '-*,bugprone-*,cppcoreguidelines-*,modernize-*,concurrency-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+CheckOptions:
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           '0'
+  - key:             llvm-else-after-return.WarnOnUnfixable
+    value:           '0'
+  - key:             llvm-qualified-auto.AddConstToQualified
+    value:           '0'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,33 +2,12 @@
 Checks:          '-*,bugprone-*,cppcoreguidelines-*,modernize-*,concurrency-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     file
 CheckOptions:
-  - key:             cert-dcl16-c.NewSuffixes
-    value:           'L;LL;LU;LLU'
-  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
-    value:           '0'
-  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
-    value:           '0'
   - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
-    value:           '1'
+    value:           'false'
   - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value:           '1'
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
-  - key:             google-readability-function-size.StatementThreshold
-    value:           '800'
-  - key:             google-readability-namespace-comments.ShortNamespaceLines
-    value:           '10'
-  - key:             google-readability-namespace-comments.SpacesBeforeComments
-    value:           '2'
-  - key:             llvm-else-after-return.WarnOnConditionVariables
-    value:           '0'
-  - key:             llvm-else-after-return.WarnOnUnfixable
-    value:           '0'
-  - key:             llvm-qualified-auto.AddConstToQualified
-    value:           '0'
   - key:             modernize-loop-convert.MaxCopySize
     value:           '16'
   - key:             modernize-loop-convert.MinConfidence

--- a/.github/workflows/clang_tidy_complete_code_review.yml
+++ b/.github/workflows/clang_tidy_complete_code_review.yml
@@ -1,0 +1,51 @@
+on:
+  workflow_dispatch:
+
+name: ClangTidyCompleteCodebaseReview
+
+jobs:
+  upload-sarif:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+        
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - run: cargo install clang-tidy-sarif sarif-fmt
+
+      - name: Generate Compilation Database
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+
+      - name: Run clang-tidy and generate SARIF files
+        run: |
+          mkdir sarif_results
+          SOURCE_FILES=$(find $GITHUB_WORKSPACE -path "$GITHUB_WORKSPACE/third_party" -prune -o -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.h' -o -name '*.hh' -o -name '*.hxx' \) -print)
+          for FILE in $SOURCE_FILES; do
+            BASENAME=$(basename -- "$FILE")
+            SARIF_FILE="sarif_results/${BASENAME%.*}.sarif"
+            USARIF_FILE="sarif_results/updated_${SARIF_BASENAME}.sarif"
+            clang-tidy -p=build "$FILE" -- | clang-tidy-sarif | tee "$SARIF_FILE"
+            # Make SARIF paths relative
+            jq --arg base "$GITHUB_WORKSPACE/" '.runs[].results[].locations[].physicalLocation.artifactLocation.uri |= sub($base; "")' "$SARIF_FILE" > "$USARIF_FILE"
+            mv "$USARIF_FILE" "$SARIF_FILE"
+            jq -s '{ version: .[0].version, runs: [ { tool: .[0].runs[0].tool, results: (map(.runs[0].results) | add) } ] }' sarif_results/*.sarif > merged_sarif_results.sarif
+          done
+
+      - name: Upload SARIF files
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: merged_sarif_results.sarif


### PR DESCRIPTION
ClangTidyCompleteReview Action:
This an on-demand workflow which can be run, to populate the existing warnings and errors into the code scanning alerts in GHAS. This can be taken up and fixed over the time. Running it again will close the fixed issues and only the remaining will be posted.

The .clang-tidy file can be used to configure the clang-tidy checks for the action.